### PR TITLE
Deleted Dockerfile and Remake docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM node:16.18.0-alpine
-# 実行フォルダ
-WORKDIR /hfmyApp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,11 @@
-version: '3.9'
-services:
-  react-app:
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-    volumes:
-      - ./hfmyApp:/hfmyApp/
-    command: sh -c "cd yui-loop && yarn start"
-    ports:
+version: '3.9'                                  # 1
+services:                                       # 2
+  hfmy-app:                                     # 3
+    container_name: hfmy-app                    # 4
+    image: node:16.18.0-alpine                  # 5
+    volumes:                                    # 6 volumes == working_dir
+      - ./hfmyApp/yui-loop:/root/hfmyApp/yui-loop
+    working_dir: /root/hfmyApp/yui-loop         # 7 pakage.jsonファイルがある位置を指定する。
+    command: sh -c 'npm install && npm start'   # 8
+    ports:                                      # 9
       - "3000:3000"
-    stdin_open: true 

--- a/hfmyApp/package-lock.json
+++ b/hfmyApp/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "hfmyApp",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Docker-composeの表記を修正
- 変更点
-- Dockerfileを削除
-- docker-compose.ymlにDockerコンテナhfmy-appを追加
-- docker-compose.ymlのcontainer_nameをhfmy-appに変更
-- Dockerfileに記述していたDockerイメージを、docker-compose.ymlのimageに移動
-- docker-compose.ymlのvolumesを- ./hfmyApp:/root/hfmyApp/に変更(pakage.jsonファイルのある場所に置く必要があった)
-- docker-compose.ymlにworking_dir: /root/hfmyApp/を追加
-- docker-compose.ymlのcommandを sh -c "npm install && npm start"に変更